### PR TITLE
Added GetPageIDByTitle(pagename, spacename)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,6 @@ Currently implemented
 	- `DeleteContent`
 	- `GetContent`
 	- `UpdateContent`
+	- `GetPageIDByTitle`
 
 This is everything I needed for my project. I might add some more functionality when I find the time. Feel free to send pull requests.

--- a/content.go
+++ b/content.go
@@ -106,7 +106,7 @@ func (w *Wiki) GetPageIDByTitle(title, space string) (string, error) {
 	}
 	contentEndPoint, err := w.contentEndpoint("")
 	if err != nil {
-		log.Println(err)
+		return "", err
 	}
 	data := url.Values{}
 	data.Set("expand", "history")


### PR DESCRIPTION
Useful if you don't want to have to go to confluence and find the page, click on page information, pull out the pageid.. etc